### PR TITLE
Use ESLint to lint Javascript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "ecmaFeatures": {
+            "jsx": false
+        }
+    },
+    "extends": "eslint:recommended",
+    "root": true
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
             "jsx": false
         }
     },
+    "env": {
+        "es6": true
+    },
     "extends": "eslint:recommended",
     "root": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ addons:
               g++-6
 
 env:
-    - CC=gcc
-    - CXX=g++
+    - CC="gcc" CXX="g++"
 
 install:
     - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 addons:
     apt:
+        sources:
+            - ubuntu-toolchain-r-test
         packages:
             - gcc-6
               g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: node_js
 install:
     - npm install
 script:
-    - node clubru.js -t
+    - node clubru.js -tl
+    - node clubru.js -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 script:
     - node clubru.js -tl
     - node clubru.js -ei
-    - node clubru.js -e
+    - bash -c "node clubru.js -e || true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: node_js
 
+addons:
+    apt:
+        packages:
+            - gcc-6
+              g++-6
+
 install:
     - npm install
 script:
     - node clubru.js -tl
+    - node clubru.js -ei
     - node clubru.js -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
             - gcc-6
               g++-6
 
+env:
+    - CC=gcc
+    - CXX=g++
+
 install:
     - npm install
 script:

--- a/clubru.js
+++ b/clubru.js
@@ -171,9 +171,40 @@ function init() {
         console.log("ClubRU should work with your current NodeJS version.");
 
     if ( arglint ) {
-        console.log("Running: eslint --ext .js / (output below)");
-        eslint = require("eslint/lib/cli");
-        eslint.execute("--ext .js /.");
+        console.log("Running: eslint (output below)");
+        eslint = require("eslint");
+        (function (cli) {
+            var report = cli.executeOnFiles(["lib/","static/js/"]);
+            var results = report.results;
+            var result, message;
+            for (var i=0;i<results.length;i++) {
+                result = results[i];
+                console.log(" FILE: "+result.filePath);
+                for (var j=0;j<result.messages.length;j++) {
+                    message = result.messages[j];
+                    console.log("  ["+message.message+"@"+message.line
+                        +":"+message.column+"]");
+                    console.log("  RULE: "+message.ruleId);
+                    console.log("  SEVERITY: "+message.severity);
+                    console.log("  MESSAGE: "+message.message);
+                    console.log("  LINE: "+message.line);
+                    console.log("  COLUMN: "+message.column);
+                    console.log("  NODETYPE: "+message.nodeType);
+                }
+            }
+            console.log(" eslint warnings: "+report.warningCount);
+            console.log(" eslint errors: "+report.errorCount);
+            console.log(" (Note: Use the eslint command for cleaner output)");
+            if ( report.errorCount > 0 ) {
+                console.warn("ERROR: ESLint found errors");
+                process.exit(1);
+            } else if ( report.warningCount > 0 ) {
+                console.log("ESLint found warnings, but no errors. This passes"
+                    +" but consider yourself on thin ice!");
+            }
+        })(new eslint.CLIEngine({
+            useEslintrc: true,
+        }));
     }
 
     if ( argtest || arglint )

--- a/lib/email.js
+++ b/lib/email.js
@@ -5,6 +5,7 @@
  *
  * TODO: Rate limiting per netid (low priority)
  */
+/* eslint-env node */
 "use strict";
 
 const sendgrid = require("sendgrid");

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -3,6 +3,7 @@
  *
  * Stores and manages data that will remain persistent between server restarts
  */
+/* eslint-env node */
 "use strict";
 
 const sqlite3 = require("sqlite3");

--- a/lib/serveauth.js
+++ b/lib/serveauth.js
@@ -4,6 +4,7 @@
  * Serves authentication pages to authorize users (ensure they're rutgers
  * students)
  */
+/* eslint-env node */
 "use strict";
 
 const path = require("path");

--- a/lib/serveauth.js
+++ b/lib/serveauth.js
@@ -7,7 +7,6 @@
 /* eslint-env node */
 "use strict";
 
-const path = require("path");
 const crypto = require("crypto");
 var argon;
 
@@ -57,11 +56,13 @@ function serveAuth(app, opts) {
                 $expire: expireTime,
             })
         }).then((succ) => {
+            if (!succ) Promise.resolve(succ);
             return email.sendValidation({
                 netid: netid,
                 token: valtoken
             });
-        }).then((r) => {
+        }).then((succ) => {
+            if (!succ) Promise.resolve(succ);
             res.send(JSON.stringify({
                 success: 1,
                 message: "You registered successfully!",

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,7 @@ const email       = require("./email");
 var running = false; 
 var lobby, expressapp, server, io, logger;
 
-function startServer(port, opts) {
+function startServer(port, opts, initCallback) {
     if (running)
         throw new Error("Server is already running.");
     running = true;
@@ -111,16 +111,20 @@ function startServer(port, opts) {
     server.listen(port);
 
     logger.info("Listening on "+":"+port);
+
+    setImmediate(function () {
+        // TODO: Wait for each module to finish first
+        initCallback();
+    });
 }
 
 function stopServer() {
     if (!running)
         throw new Error("Server is not running.");
 
-    // TODO
-    // running = false;
-
-    throw new Error("Not Yet Implemented!");
+    running = false;
+    // TODO: Gracefully tell all modules to stop
+    return;
 }
 
 module.exports = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@
  *  - Websockets Server
  *  - Authentication Server
  */
+/* eslint-env node */
 
 "use strict";
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,14 +22,18 @@ const persistence = require("./persistence");
 const email       = require("./email");
 
 var running = false; 
-var lobby, expressapp, server, io, logger;
+var expressapp, server, logger;
 
 function startServer(port, opts, initCallback) {
     if (running)
         throw new Error("Server is already running.");
     running = true;
 
+    /* eslint-disable */
+    // This will help catch any problems with logging
     console.log("Switching to Winston for logging...");
+    /* eslint-enable */
+
     logger = new winston.Logger({
         transports: [
             new winston.transports.Console({

--- a/lib/servesocket.js
+++ b/lib/servesocket.js
@@ -3,6 +3,7 @@
  *
  * Handles the socket.io backend
  */
+/* eslint-env node */
 "use strict";
 
 const socketio = require("socket.io");

--- a/lib/servestatic.js
+++ b/lib/servestatic.js
@@ -3,6 +3,7 @@
  *
  * Serves the /static directory.
  */
+/* eslint-env node */
 "use strict";
 
 const path = require("path");

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "winston": "^2.3.1"
   },
   "optionalDependencies": {
-    "argon2": "^0.15.0"
+    "argon2": "^0.15.0",
+    "eslint": "^3.17.1"
   }
 }

--- a/static/js/clubknight.js
+++ b/static/js/clubknight.js
@@ -3,6 +3,7 @@
  *
  * Client-Side Rendering
  */
+/* eslint-env browser */
 "use strict";
 
 var play = (function () {

--- a/static/js/clubknight.js
+++ b/static/js/clubknight.js
@@ -4,14 +4,15 @@
  * Client-Side Rendering
  */
 /* eslint-env browser */
+/* global PIXI */
 "use strict";
 
 var play = (function () {
 
 const ASSET_SERVER = "https://cdn-clubknight-world.s3.amazonaws.com";
 
-var $ =  (q)=>document.querySelector(q),
-    $$ = (q)=>document.querySelectorAll(q);
+var $  = (q)=>document.querySelector(q);
+//  $$ = (q)=>document.querySelectorAll(q);
 
 var renderer = null;
 var stage = null;
@@ -43,7 +44,7 @@ function setup() {
     button1.hitArea = new PIXI.Rectangle(10,300,250,200);
     button1.interactive = true;
     button1.buttonMode = true;
-    button1.on("pointerdown", (e)=>{
+    button1.on("pointerdown", ()=>{
         document.location.href = "/register.html";
     });
     stage.addChild(button1);
@@ -52,7 +53,7 @@ function setup() {
     button2.hitArea = new PIXI.Rectangle(150,400,350,176);
     button2.interactive = true;
     button2.buttonMode = true;
-    button2.on("pointerdown", (e)=>{
+    button2.on("pointerdown", ()=>{
         document.location.href = "/login.html";
     });
     stage.addChild(button2)
@@ -65,7 +66,6 @@ function setup() {
 return {
     init,
 
-    _socket: ()=>socket,
     _renderer: ()=>renderer,
     _stage: ()=>stage,
 };

--- a/static/js/global.js
+++ b/static/js/global.js
@@ -4,7 +4,7 @@
  * Global functions, and check browser support. Avoid modern javascript
  * features.
  */
-/* eslint-env browser */
+/* eslint-disable */
 
 var badSupportDialog;
 
@@ -107,6 +107,7 @@ function initDynamicForm(form) {
                 console.log("error", revt);
                 sbmter.disabled = false;
 
+                var resText;
                 for (var i=0;i<responseFields.length;i++) {
                     responseFields[i].innerHTML = "";
                     resText = document.createTextNode(

--- a/static/js/global.js
+++ b/static/js/global.js
@@ -4,6 +4,7 @@
  * Global functions, and check browser support. Avoid modern javascript
  * features.
  */
+/* eslint-env browser */
 
 var badSupportDialog;
 

--- a/static/js/lobby.js
+++ b/static/js/lobby.js
@@ -7,6 +7,7 @@
  *  - Client/Server communication
  *  - Player Prediction
  */
+/* eslint-env browser */
 
 var lobby = (function () {
 

--- a/static/js/lobby.js
+++ b/static/js/lobby.js
@@ -19,3 +19,5 @@ return {
 };
 
 })();
+
+void(lobby);

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -3,3 +3,4 @@
  *
  * Handles custom logic for /login.html
  */
+/* eslint-env browser */

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -3,5 +3,6 @@
  *
  * Handles custom logic form /register.html
  */
+/* eslint-env browser */
 
 //TODO: Don't let users submit unless they agree

--- a/static/js/validate.js
+++ b/static/js/validate.js
@@ -3,3 +3,4 @@
  *
  * Handles custom logic for /validate.html
  */
+/* eslint-env browser */


### PR DESCRIPTION
I've had multiple bugs that took way to long to solve that could have easily been fixed with a linter. Forgetting to put return or using an incorrect variable name, for instance. This will both add a linter andn force PRs to properly pass the linting.

Note when linting on your own code its probably best *not* to use `node clubru.js -e` as travis does. The output is really difficult to understand but not worth improving when you can just run `node node_modules/eslint/bin/eslint.js ...` instead.